### PR TITLE
Fix compilation post Esphome 2023.6

### DIFF
--- a/components/tm1650/tm1650.cpp
+++ b/components/tm1650/tm1650.cpp
@@ -151,7 +151,7 @@ uint8_t TM1650Display::printf(const char *format, ...) {
   return 0;
 }
 
-uint8_t TM1650Display::strftime(uint8_t pos, const char *format, time::ESPTime time) {
+uint8_t TM1650Display::strftime(uint8_t pos, const char *format, ESPTime time) {
   char buffer[64];
   size_t ret = time.strftime(buffer, sizeof(buffer), format);
   if (ret > 0)
@@ -159,7 +159,7 @@ uint8_t TM1650Display::strftime(uint8_t pos, const char *format, time::ESPTime t
   return 0;
 }
 
-uint8_t TM1650Display::strftime(const char *format, time::ESPTime time) {
+uint8_t TM1650Display::strftime(const char *format, ESPTime time) {
   return this->strftime(0, format, time);
 }
 

--- a/components/tm1650/tm1650.h
+++ b/components/tm1650/tm1650.h
@@ -40,8 +40,8 @@ class TM1650Display : public PollingComponent, public i2c::I2CDevice {
   uint8_t print(uint8_t pos, const char *str);
   uint8_t print(const char *str);
 
-  uint8_t strftime(uint8_t pos, const char *format, time::ESPTime time) __attribute__((format(strftime, 3, 0)));
-  uint8_t strftime(const char *format, time::ESPTime time) __attribute__((format(strftime, 2, 0)));
+  uint8_t strftime(uint8_t pos, const char *format, ESPTime time) __attribute__((format(strftime, 3, 0)));
+  uint8_t strftime(const char *format, ESPTime time) __attribute__((format(strftime, 2, 0)));
 
  protected:
   uint8_t intensity_;


### PR DESCRIPTION
Hi, this fixes the breaking change for custom components using ESPTime in Esphome 2023.6

See https://github.com/esphome/esphome/pull/4926

Great custom component btw, i just got my clock set up after it lying on my desk for months. You may want to squash the commit messages as some of them are non sensical

